### PR TITLE
Add example support for BlazingCache

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,21 @@
     </dependency>
 
     <!-- Use Hazelcast as JCache provider for test -->
+    <!--
     <dependency>
       <groupId>com.hazelcast</groupId>
       <artifactId>hazelcast</artifactId>
       <version>3.4.1</version>
       <scope>test</scope>
+    </dependency>
+    -->
+    
+    <!-- Use BlazingCache as JCache provider for test -->
+    <dependency>
+        <groupId>org.blazingcache</groupId>
+        <artifactId>blazingcache-jcache</artifactId>
+        <version>1.9.2</version>
+        <scope>test</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
I tested this project on BlazingCache. This PR adds a configuration example to the pom.xml.
Maybe it would be usefull to provide the user to select the Provider, using a System Property or other configuration feature.
I can enhance the PR, leaving the default to Hazelcast
